### PR TITLE
Log PDF rendering errors

### DIFF
--- a/pyqt-pdf-analyzer/ui/main_window.py
+++ b/pyqt-pdf-analyzer/ui/main_window.py
@@ -2,6 +2,7 @@
 Main window for the PyQt PDF Document Analyzer.
 """
 
+import logging
 import os
 from PyQt6.QtWidgets import (
     QMainWindow, QWidget, QHBoxLayout, QVBoxLayout,
@@ -38,6 +39,7 @@ class PDFRenderThread(QThread):
             else:
                 self.error_occurred.emit(f"Failed to render page {self.page_number + 1}")
         except Exception as e:
+            logging.exception("Error rendering page")
             self.error_occurred.emit(f"Error rendering page: {str(e)}")
 
 class MainWindow(QMainWindow):


### PR DESCRIPTION
## Summary
- log PDF page rendering errors using `logging.exception`
- continue emitting UI error signal after logging

## Testing
- `python -m py_compile pyqt-pdf-analyzer/ui/main_window.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a69c8a3288832dba947ee1530857d9