### PR TITLE
Log PDF errors in main window

### DIFF
--- a/pyqt-pdf-analyzer/ui/main_window.py
+++ b/pyqt-pdf-analyzer/ui/main_window.py
@@ -2,6 +2,7 @@
 Main window for the PyQt PDF Document Analyzer.
 """
 
+import logging
 import os
 from PyQt6.QtWidgets import (
     QMainWindow, QWidget, QHBoxLayout, QVBoxLayout,
@@ -237,6 +238,7 @@ class MainWindow(QMainWindow):
             self._render_current_page()
 
     def _on_pdf_error(self, msg: str):
+        logging.error(msg)
         QMessageBox.warning(self, "PDF Error", msg)
         self.status_bar.showMessage(f"Error: {msg}")
 


### PR DESCRIPTION
## Summary
- Add logging import to main window
- Log PDF-related errors before displaying the warning dialog

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a69c8d602c832d8398cfa802901dbe