### PR TITLE
Use logging for data loading failures

### DIFF
--- a/pyqt-pdf-analyzer/core/keyword_manager.py
+++ b/pyqt-pdf-analyzer/core/keyword_manager.py
@@ -3,11 +3,14 @@ Keyword and URL validation management for PDF analysis.
 Handles loading, filtering, and categorizing keywords and URL validations from CSV files.
 """
 
+import logging
 import pandas as pd
 import re
 from typing import Dict, List, Set, Optional
 from dataclasses import dataclass
 from core.config import Config
+
+logger = logging.getLogger(__name__)
 
 @dataclass
 class Keyword:
@@ -105,8 +108,8 @@ class KeywordManager:
             
             return True
             
-        except Exception as e:
-            print(f"Error loading keywords: {e}")
+        except Exception:
+            logger.exception("Error loading keywords")
             return False
     
     def get_categories(self) -> List[str]:
@@ -234,8 +237,8 @@ class KeywordManager:
             
             return True
             
-        except Exception as e:
-            print(f"Error loading URL validations: {e}")
+        except Exception:
+            logger.exception("Error loading URL validations")
             return False
     
     def get_url_statuses(self) -> List[str]:

--- a/pyqt-pdf-analyzer/core/keyword_provider.py
+++ b/pyqt-pdf-analyzer/core/keyword_provider.py
@@ -1,7 +1,10 @@
+import logging
 import pandas as pd
 from typing import List, Set, Dict
 from core.annotation_system import AnnotationProvider, Annotation, AnnotationType
 from core.config import Config
+
+logger = logging.getLogger(__name__)
 
 class KeywordProvider(AnnotationProvider):
     """Provides keyword-based annotations."""
@@ -23,8 +26,8 @@ class KeywordProvider(AnnotationProvider):
             self._build_keyword_lookup()
             self.enabled_categories = set(self.keywords_df['category'].unique())
             return True
-        except Exception as e:
-            print(f"Error loading keywords: {e}")
+        except Exception:
+            logger.exception("Error loading keywords")
             return False
     
     def _build_keyword_lookup(self):

--- a/pyqt-pdf-analyzer/core/url_provider.py
+++ b/pyqt-pdf-analyzer/core/url_provider.py
@@ -1,8 +1,11 @@
+import logging
 import pandas as pd
 import re
 from typing import List, Set, Dict
 from core.annotation_system import AnnotationProvider, Annotation, AnnotationType
 from core.config import Config
+
+logger = logging.getLogger(__name__)
 
 class URLProvider(AnnotationProvider):
     """Provides URL validation annotations."""
@@ -32,8 +35,8 @@ class URLProvider(AnnotationProvider):
             self._build_lookup()
             self.enabled_categories = set(self.validations_df['status'].unique())
             return True
-        except Exception as e:
-            print(f"Error loading URL validations: {e}")
+        except Exception:
+            logger.exception("Error loading URL validations")
             return False
     
     def _build_lookup(self):


### PR DESCRIPTION
## Summary
- replace print statements with logging in keyword, URL provider, and keyword manager loaders

## Testing
- `python -m py_compile pyqt-pdf-analyzer/core/keyword_provider.py pyqt-pdf-analyzer/core/url_provider.py pyqt-pdf-analyzer/core/keyword_manager.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a69c905f14832d8594d182021be447