### PR TITLE
refactor: share CSV annotation base and URL regex patterns

### DIFF
--- a/pyqt-pdf-analyzer/core/base_csv_provider.py
+++ b/pyqt-pdf-analyzer/core/base_csv_provider.py
@@ -1,0 +1,57 @@
+import logging
+from typing import List, Set
+
+import pandas as pd
+
+from core.annotation_system import AnnotationProvider
+
+logger = logging.getLogger(__name__)
+
+
+class BaseCSVAnnotationProvider(AnnotationProvider):
+    """Base class for annotation providers backed by CSV data."""
+
+    required_columns: List[str] = []
+    category_column: str = "category"
+
+    def __init__(self) -> None:
+        self.data_df: pd.DataFrame = pd.DataFrame()
+        self.enabled_categories: Set[str] = set()
+
+    def get_default_source_path(self) -> str:
+        """Get default path for CSV source."""
+        raise NotImplementedError
+
+    def _post_load(self) -> None:
+        """Hook for subclasses to process data after loading."""
+        pass
+
+    def load_data(self, source_path: str = None) -> bool:
+        """Load annotation data from CSV file."""
+        if source_path is None:
+            source_path = self.get_default_source_path()
+        try:
+            self.data_df = pd.read_csv(source_path)
+            if not all(col in self.data_df.columns for col in self.required_columns):
+                raise ValueError(f"CSV must contain columns: {self.required_columns}")
+            self.enabled_categories = set(self.data_df[self.category_column].unique())
+            self._post_load()
+            return True
+        except Exception:
+            logger.exception("Error loading data")
+            return False
+
+    def get_categories(self) -> Set[str]:
+        """Get all categories present in the data."""
+        return set(self.data_df[self.category_column].unique()) if not self.data_df.empty else set()
+
+    def get_enabled_categories(self) -> Set[str]:
+        """Get currently enabled categories."""
+        return self.enabled_categories.copy()
+
+    def set_category_enabled(self, category: str, enabled: bool) -> None:
+        """Enable or disable a category."""
+        if enabled:
+            self.enabled_categories.add(category)
+        else:
+            self.enabled_categories.discard(category)

--- a/pyqt-pdf-analyzer/core/keyword_manager.py
+++ b/pyqt-pdf-analyzer/core/keyword_manager.py
@@ -8,7 +8,9 @@ import pandas as pd
 import re
 from typing import Dict, List, Set, Optional
 from dataclasses import dataclass
+
 from core.config import Config
+from core.url_utils import COMPILED_URL_PATTERNS
 
 logger = logging.getLogger(__name__)
 
@@ -57,13 +59,7 @@ class KeywordManager:
         self._url_lookup: Dict[str, URLValidation] = {}
         
         # URL detection patterns
-        self.url_patterns = [
-            r'https?://[^\s<>"{}|\\^`\[\]]+',  # Standard HTTP/HTTPS
-            r'www\.[^\s<>"{}|\\^`\[\]]+',      # www. domains
-            r'[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}(?:/[^\s<>"{}|\\^`\[\]]*)?',  # domain.com
-            r'mailto:[^\s<>"{}|\\^`\[\]]+'     # Email addresses
-        ]
-        self.compiled_patterns = [re.compile(pattern, re.IGNORECASE) for pattern in self.url_patterns]
+        self.compiled_patterns = COMPILED_URL_PATTERNS
         
     def load_keywords(self, csv_path: str = None) -> bool:
         """

--- a/pyqt-pdf-analyzer/core/keyword_provider.py
+++ b/pyqt-pdf-analyzer/core/keyword_provider.py
@@ -1,39 +1,32 @@
 import logging
-import pandas as pd
-from typing import List, Set, Dict
-from core.annotation_system import AnnotationProvider, Annotation, AnnotationType
+from typing import List, Dict
+
+from core.annotation_system import Annotation, AnnotationType
+from core.base_csv_provider import BaseCSVAnnotationProvider
 from core.config import Config
 
 logger = logging.getLogger(__name__)
 
-class KeywordProvider(AnnotationProvider):
+class KeywordProvider(BaseCSVAnnotationProvider):
     """Provides keyword-based annotations."""
-    
+
+    required_columns = ["keyword", "category", "color"]
+    category_column = "category"
+
     def __init__(self):
-        self.keywords_df: pd.DataFrame = pd.DataFrame()
-        self.enabled_categories: Set[str] = set()
+        super().__init__()
         self._keyword_lookup: Dict[str, List[Annotation]] = {}
-    
-    def load_data(self, source_path: str = None) -> bool:
-        """Load keywords from CSV file."""
-        if source_path is None:
-            source_path = Config.get_keywords_path()
-        try:
-            self.keywords_df = pd.read_csv(source_path)
-            required_cols = ['keyword', 'category', 'color']
-            if not all(col in self.keywords_df.columns for col in required_cols):
-                raise ValueError(f"CSV must contain columns: {required_cols}")
-            self._build_keyword_lookup()
-            self.enabled_categories = set(self.keywords_df['category'].unique())
-            return True
-        except Exception:
-            logger.exception("Error loading keywords")
-            return False
+
+    def get_default_source_path(self) -> str:
+        return Config.get_keywords_path()
+
+    def _post_load(self) -> None:
+        self._build_keyword_lookup()
     
     def _build_keyword_lookup(self):
         """Build lookup of keyword text to Annotation instances."""
         self._keyword_lookup.clear()
-        for _, row in self.keywords_df.iterrows():
+        for _, row in self.data_df.iterrows():
             text = str(row['keyword']).lower()
             annotation = Annotation(
                 text=text,
@@ -57,17 +50,3 @@ class KeywordProvider(AnnotationProvider):
                         found.append(ann)
         return found
     
-    def get_categories(self) -> Set[str]:
-        """Get all keyword categories."""
-        return set(self.keywords_df['category'].unique()) if not self.keywords_df.empty else set()
-    
-    def get_enabled_categories(self) -> Set[str]:
-        """Get enabled keyword categories."""
-        return self.enabled_categories.copy()
-    
-    def set_category_enabled(self, category: str, enabled: bool):
-        """Enable or disable a keyword category."""
-        if enabled:
-            self.enabled_categories.add(category)
-        else:
-            self.enabled_categories.discard(category)

--- a/pyqt-pdf-analyzer/core/url_utils.py
+++ b/pyqt-pdf-analyzer/core/url_utils.py
@@ -1,0 +1,11 @@
+import re
+
+# Common URL detection patterns used across the application.
+URL_PATTERNS = [
+    r'https?://[^\s<>"{}|\^`\[\]]+',
+    r'www\.[^\s<>"{}|\^`\[\]]+',
+    r'[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}(?:/[^\s<>"{}|\^`\[\]]*)?',
+    r'mailto:[^\s<>"{}|\^`\[\]]+'
+]
+
+COMPILED_URL_PATTERNS = [re.compile(p, re.IGNORECASE) for p in URL_PATTERNS]


### PR DESCRIPTION
## Summary
- extract BaseCSVAnnotationProvider to handle CSV loading and category management
- centralize URL regex patterns in core.url_utils
- refactor providers and manager to use new base class and shared URL patterns

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a6aff84f84832d99ad3fc95b120cd8