### PR TITLE
refactor metadata extraction for PDF highlighting

### DIFF
--- a/pyqt-pdf-analyzer/core/__init__.py
+++ b/pyqt-pdf-analyzer/core/__init__.py
@@ -3,10 +3,13 @@ Core modules for the PyQt PDF Document Analyzer.
 """
 
 from .config import Config
-from .pdf_processor import PDFProcessor, PageMetadata
+from .pdf_processor import PDFProcessor
+from .page_metadata import PageMetadata
+from .metadata_builder import PageMetadataBuilder
 
 __all__ = [
     'Config',
     'PDFProcessor',
-    'PageMetadata'
+    'PageMetadata',
+    'PageMetadataBuilder'
 ]

--- a/pyqt-pdf-analyzer/core/annotation_system.py
+++ b/pyqt-pdf-analyzer/core/annotation_system.py
@@ -102,6 +102,15 @@ class AnnotationManager:
         with QMutexLocker(self._cache_mutex):
             return self.find_annotations_cached(key, text)
 
+    def find_annotations_batch(self, texts: List[str]) -> List[List[Annotation]]:
+        """Find annotations for a batch of texts with a single lock acquisition."""
+        keys = [self._get_cache_key(t) for t in texts]
+        logging.debug(
+            "AnnotationManager.find_annotations_batch: batch_size=%d", len(texts)
+        )
+        with QMutexLocker(self._cache_mutex):
+            return [self.find_annotations_cached(k, t) for k, t in zip(keys, texts)]
+
     def _find_annotations_impl(self, key: str, text: str) -> List[Annotation]:
         """Implementation for computing annotations for given text."""
         all_annotations: List[Annotation] = []

--- a/pyqt-pdf-analyzer/core/metadata_builder.py
+++ b/pyqt-pdf-analyzer/core/metadata_builder.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+"""Utilities for extracting PDF page metadata."""
+
+from dataclasses import dataclass
+from typing import List, Dict
+import fitz
+import logging
+
+from .annotation_system import AnnotationManager, AnnotationType
+from .page_metadata import PageMetadata
+
+
+@dataclass
+class PageMetadataBuilder:
+    """Builds :class:`PageMetadata` instances from a PyMuPDF document."""
+
+    annotation_manager: AnnotationManager
+
+    def build(self, document: fitz.Document, page_num: int) -> PageMetadata:
+        """Extract text, bounding boxes and annotations for a page."""
+        logging.debug(
+            "PageMetadataBuilder.build: start extraction for page %d", page_num
+        )
+        page = document.load_page(page_num)
+        text_content = page.get_text()
+        blocks = page.get_text("dict").get("blocks", [])
+
+        boxes: List[Dict] = []
+        span_texts: List[str] = []
+        for block in blocks:
+            for line in block.get("lines", []):
+                for span in line.get("spans", []):
+                    x0, y0, x1, y1 = span["bbox"]
+                    boxes.append(
+                        {
+                            "x0": x0,
+                            "y0": y0,
+                            "x1": x1,
+                            "y1": y1,
+                            "text": span["text"],
+                        }
+                    )
+                    span_texts.append(span["text"])
+
+        # Batch annotation lookup for span texts
+        annotations_batch = self.annotation_manager.find_annotations_batch(span_texts)
+        for bbox, anns in zip(boxes, annotations_batch):
+            bbox["annotations"] = anns
+
+        # Page-level annotations
+        page_annotations = self.annotation_manager.find_all_annotations_in_text(
+            text_content
+        )
+        kws = [a for a in page_annotations if a.annotation_type == AnnotationType.KEYWORD]
+        urls = [
+            a
+            for a in page_annotations
+            if a.annotation_type == AnnotationType.URL_VALIDATION
+        ]
+
+        logging.debug(
+            "PageMetadataBuilder.build: extracted %d boxes for page %d",
+            len(boxes),
+            page_num,
+        )
+        return PageMetadata(page_num, text_content, boxes, kws, urls)
+

--- a/pyqt-pdf-analyzer/core/page_metadata.py
+++ b/pyqt-pdf-analyzer/core/page_metadata.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+from typing import List, Dict
+
+from .annotation_system import Annotation
+
+
+@dataclass
+class PageMetadata:
+    """Metadata for a single PDF page."""
+
+    page_number: int
+    content: str
+    bounding_boxes: List[Dict]
+    keywords_found: List[Annotation]
+    urls_found: List[Annotation]
+

--- a/pyqt-pdf-analyzer/ui/main_window.py
+++ b/pyqt-pdf-analyzer/ui/main_window.py
@@ -18,7 +18,8 @@ from core.config import Config
 from core.keyword_provider import KeywordProvider
 from core.url_provider import URLProvider
 from core.annotation_system import AnnotationManager, AnnotationType
-from core.pdf_processor import PDFProcessor, PageMetadata
+from core.pdf_processor import PDFProcessor
+from core.page_metadata import PageMetadata
 from core.debug_processor import DebugPDFProcessor
 from ui.debug_toolbar import DebugToolbar, DebugLogWidget
 from ui.pdf_viewer import PDFViewerWidget


### PR DESCRIPTION
## Summary
- Precompute span annotations once during metadata extraction and reuse during rendering
- Introduce `PageMetadataBuilder` and standalone `PageMetadata` dataclass
- Add batched annotation lookup to `AnnotationManager`

## Testing
- `pytest -q` *(fails: No module named 'PyQt6')*


------
https://chatgpt.com/codex/tasks/task_e_68a76a7adeec832db3bf4adfeb16e0ee