### PR TITLE
Use queued worker thread for PDF rendering

### DIFF
--- a/pyqt-pdf-analyzer/tests/test_priority2_threading.py
+++ b/pyqt-pdf-analyzer/tests/test_priority2_threading.py
@@ -10,66 +10,70 @@ def _get_qapp():
     """Get or create a QApplication instance for testing."""
     return QApplication.instance() or QApplication(sys.argv)
 
-def test_pdf_render_thread_creation():
-    """PDFRenderThread can be instantiated without starting."""
+def test_pdf_render_worker_creation():
+    """PDFRenderWorker can be instantiated and started."""
     from core.pdf_processor import PDFProcessor
     from core.annotation_system import AnnotationManager
-    from ui.main_window import PDFRenderThread
+    from ui.main_window import PDFRenderWorker
 
     manager = AnnotationManager()
     processor = PDFProcessor(manager)
-    thread = PDFRenderThread(processor, page_number=0, zoom_level=1.0)
-    assert thread.page_number == 0
-    assert thread.zoom_level == 1.0
+    worker = PDFRenderWorker(processor)
+    assert not worker.isRunning()
+    worker.start()
+    worker.stop()
 
-def test_pdf_render_thread_signals_success(qtbot):
-    """Thread emits page_rendered signal on successful render."""
+def test_pdf_render_worker_signals_success(qtbot):
+    """Worker emits page_rendered signal on successful render."""
     app = _get_qapp()
     from core.annotation_system import AnnotationManager
     from core.pdf_processor import PDFProcessor
-    from ui.main_window import PDFRenderThread
+    from ui.main_window import PDFRenderWorker
 
     proc = PDFProcessor(AnnotationManager())
     assert proc.load_pdf("lib/ufc_word_template_05_06_2025.pdf")
 
-    thread = PDFRenderThread(proc, page_number=0, zoom_level=1.0)
-    with qtbot.waitSignal(thread.page_rendered, timeout=5000) as spy:
-        thread.start()
+    worker = PDFRenderWorker(proc)
+    worker.start()
+    with qtbot.waitSignal(worker.page_rendered, timeout=5000) as spy:
+        worker.request_render(0, 1.0)
 
     image, page_num = spy.args
     assert page_num == 0
     assert hasattr(image, 'width') and image.width() > 0
+    worker.stop()
 
-def test_pdf_render_thread_signals_error(qtbot):
-    """Thread emits error_occurred for invalid page index."""
+def test_pdf_render_worker_signals_error(qtbot):
+    """Worker emits error_occurred for invalid page index."""
     app = _get_qapp()
     from core.annotation_system import AnnotationManager
     from core.pdf_processor import PDFProcessor
-    from ui.main_window import PDFRenderThread
+    from ui.main_window import PDFRenderWorker
 
     proc = PDFProcessor(AnnotationManager())
     assert proc.load_pdf("lib/ufc_word_template_05_06_2025.pdf")
 
-    thread = PDFRenderThread(proc, page_number=9999, zoom_level=1.0)
-    with qtbot.waitSignal(thread.error_occurred, timeout=5000) as spy:
-        thread.start()
+    worker = PDFRenderWorker(proc)
+    worker.start()
+    with qtbot.waitSignal(worker.error_occurred, timeout=5000) as spy:
+        worker.request_render(9999, 1.0)
 
     err_msg, = spy.args
     assert "Failed to render page" in err_msg or "Error rendering page" in err_msg
+    worker.stop()
 
-def test_pdf_render_thread_terminate(qtbot):
-    """Thread can be terminated safely while running."""
+def test_pdf_render_worker_stop(qtbot):
+    """Worker can be stopped safely while running."""
     app = _get_qapp()
     from core.annotation_system import AnnotationManager
     from core.pdf_processor import PDFProcessor
-    from ui.main_window import PDFRenderThread
+    from ui.main_window import PDFRenderWorker
 
     proc = PDFProcessor(AnnotationManager())
     assert proc.load_pdf("lib/ufc_word_template_05_06_2025.pdf")
 
-    thread = PDFRenderThread(proc, page_number=0, zoom_level=1.0)
-    thread.start()
+    worker = PDFRenderWorker(proc)
+    worker.start()
     qtbot.wait(50)
-    thread.terminate()
-    thread.wait()
-    assert not thread.isRunning()
+    worker.stop()
+    assert not worker.isRunning()

--- a/pyqt-pdf-analyzer/ui/main_window.py
+++ b/pyqt-pdf-analyzer/ui/main_window.py
@@ -4,13 +4,14 @@ Main window for the PyQt PDF Document Analyzer.
 
 import logging
 import os
+import queue
 from PyQt6.QtWidgets import (
     QMainWindow, QWidget, QHBoxLayout, QVBoxLayout,
     QMenuBar, QMenu, QStatusBar, QFileDialog,
     QMessageBox, QSplitter, QProgressBar, QLabel,
     QToolBar, QApplication
 )
-from PyQt6.QtCore import Qt, QTimer, QThread, pyqtSignal
+from PyQt6.QtCore import Qt, QTimer, QThread, pyqtSignal, pyqtSlot
 from PyQt6.QtGui import QAction, QIcon, QKeySequence, QImage
 from typing import Optional, Dict, Any
 
@@ -25,32 +26,47 @@ from ui.pdf_viewer import PDFViewerWidget
 from ui.keyword_panel import KeywordPanel
 
 
-class PDFRenderThread(QThread):
-    """Thread for rendering PDF pages without blocking the UI."""
+class PDFRenderWorker(QThread):
+    """Long-lived thread processing queued page render requests."""
     page_rendered = pyqtSignal(QImage, int)
     error_occurred = pyqtSignal(str)
 
-    def __init__(
-            self,
-            pdf_processor: PDFProcessor,
-            page_number: int,
-            zoom_level: float):
+    def __init__(self, pdf_processor: PDFProcessor):
         super().__init__()
         self.pdf_processor = pdf_processor
-        self.page_number = page_number
-        self.zoom_level = zoom_level
+        self._queue: "queue.Queue[tuple[int, float]]" = queue.Queue()
+        self._running = True
 
-    def run(self):
-        try:
-            image = self.pdf_processor.render_page(
-                self.page_number, self.zoom_level)
-            if image:
-                self.page_rendered.emit(image, self.page_number)
-            else:
-                self.error_occurred.emit(f"Failed to render page {self.page_number + 1}")
-        except Exception as e:
-            logging.exception("Error rendering page")
-            self.error_occurred.emit(f"Error rendering page: {str(e)}")
+    @pyqtSlot(int, float)
+    def request_render(self, page_number: int, zoom_level: float) -> None:
+        """Queue a page render request, keeping only the most recent one."""
+        while not self._queue.empty():
+            try:
+                self._queue.get_nowait()
+            except queue.Empty:
+                break
+        self._queue.put((page_number, zoom_level))
+
+    def run(self) -> None:
+        while self._running:
+            page_number, zoom_level = self._queue.get()
+            if page_number is None:
+                break
+            try:
+                image = self.pdf_processor.render_page(page_number, zoom_level)
+                if image:
+                    self.page_rendered.emit(image, page_number)
+                else:
+                    self.error_occurred.emit(
+                        f"Failed to render page {page_number + 1}")
+            except Exception as e:
+                logging.exception("Error rendering page")
+                self.error_occurred.emit(f"Error rendering page: {str(e)}")
+
+    def stop(self) -> None:
+        self._running = False
+        self._queue.put((None, 0.0))
+        self.wait()
 
 
 class MainWindow(QMainWindow):
@@ -69,7 +85,7 @@ class MainWindow(QMainWindow):
             AnnotationType.URL_VALIDATION, self.url_provider)
         # Register renderers inside PDFProcessor
         self.pdf_processor = DebugPDFProcessor(self.annotation_manager)
-        self.current_render_thread: Optional[PDFRenderThread] = None
+        self.render_thread = PDFRenderWorker(self.pdf_processor)
 
         # UI components
         self.pdf_viewer: Optional[PDFViewerWidget] = None
@@ -79,6 +95,15 @@ class MainWindow(QMainWindow):
 
         self._setup_ui()
         self._setup_connections()
+        # Render worker connections
+        self.render_thread.page_rendered.connect(self.pdf_viewer.set_pixmap)
+        self.render_thread.error_occurred.connect(self._on_pdf_error)
+        self.render_thread.start()
+
+        # Debounce timer for render requests
+        self._render_timer = QTimer(self)
+        self._render_timer.setSingleShot(True)
+        self._render_timer.timeout.connect(self._render_current_page)
 
         # Debug UI integration
         self.debug_toolbar = DebugToolbar(self)
@@ -266,23 +291,15 @@ class MainWindow(QMainWindow):
             return
         page = self.pdf_viewer.get_current_page()
         zoom = self.pdf_viewer.get_zoom_level()
-        if self.current_render_thread and self.current_render_thread.isRunning():
-            self.current_render_thread.terminate()
-            self.current_render_thread.wait()
-        self.current_render_thread = PDFRenderThread(
-            self.pdf_processor, page, zoom)
-        self.current_render_thread.page_rendered.connect(
-            self.pdf_viewer.set_pixmap)
-        self.current_render_thread.error_occurred.connect(self._on_pdf_error)
-        self.current_render_thread.start()
+        self.render_thread.request_render(page, zoom)
         self._update_page_metadata(page)
 
     def _on_page_changed(self, page_number: int):
-        self._render_current_page()
+        self._render_timer.start(150)
         self.status_bar.showMessage(f"Page {page_number + 1}")
 
     def _on_zoom_changed(self, zoom_level: float):
-        self._render_current_page()
+        self._render_timer.start(150)
         self.status_bar.showMessage(f"Zoom: {int(zoom_level * 100)}%")
 
     def _on_category_toggled(self, category: str, enabled: bool):
@@ -349,8 +366,7 @@ class MainWindow(QMainWindow):
             pass
 
     def closeEvent(self, event):
-        if self.current_render_thread and self.current_render_thread.isRunning():
-            self.current_render_thread.terminate()
-            self.current_render_thread.wait()
+        if self.render_thread.isRunning():
+            self.render_thread.stop()
         self.pdf_processor.close_document()
         event.accept()


### PR DESCRIPTION
## Summary
- replace per-render thread creation with a long-lived `PDFRenderWorker`
- expose `request_render` slot and connect worker signals in `MainWindow` constructor
- debounce page/zoom change events to avoid rapid rendering
- update tests for worker-based API

## Testing
- `pytest -q` *(fails: No module named 'PyQt6')*
- `pip install PyQt6 -q` *(fails: Could not find a version that satisfies the requirement PyQt6)*

------
https://chatgpt.com/codex/tasks/task_e_68a76a82ac00832dad3ce6069aaf4b6f