### PR TITLE
chore: remove leftover debug and unused imports

### DIFF
--- a/src/UFGS_utils.py
+++ b/src/UFGS_utils.py
@@ -4,9 +4,7 @@ import zipfile
 import requests
 import pandas as pd
 from lxml import etree
-from openpyxl.styles import Alignment, Font
 from openpyxl.worksheet.table import Table, TableStyleInfo
-from openpyxl import Workbook
 
 # --- Global Debug Toggle ---
 DEBUG_MODE = False

--- a/streamlit-test/app.py
+++ b/streamlit-test/app.py
@@ -10,10 +10,7 @@ import os
 st.set_page_config(layout="wide")
 st.title("📄 UFC PDF Visualizer with Keyword Pills")
 
-# Add diagnostic print
-st.write("Files in directory:", os.listdir("streamlit-test/"))
-
-# Then attempt to read
+# Load keywords
 keyword_df = pd.read_csv("streamlit-test/keywords.csv")
 
 keyword_map = {


### PR DESCRIPTION
## Summary
- remove diagnostic print after button/menu cleanup
- drop unused openpyxl imports

## Testing
- `ruff check streamlit-test/app.py src/UFGS_utils.py`
- `python -m py_compile streamlit-test/app.py src/UFGS_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_68a78577b414832d85b66f1d1e9026ff