### PR TITLE
refactor: use async function for fallback

### DIFF
--- a/src/UFGS_CheckAllURLs_v4.py
+++ b/src/UFGS_CheckAllURLs_v4.py
@@ -35,7 +35,9 @@ try:
 except ImportError as e:
     print(f"CRITICAL ERROR: Could not import required async components from 'reachable': {e}")
     print("Please ensure 'reachable==0.7.0' (AlexMili/Reachable on PyPI) is installed correctly.")
-    is_reachable_async_func = lambda *args, **kwargs: asyncio.sleep(0)
+    async def placeholder_is_reachable_async(*args, **kwargs):
+        await asyncio.sleep(0)
+    is_reachable_async_func = placeholder_is_reachable_async
     class AsyncClientPlaceholder:
         async def __aenter__(self): await asyncio.sleep(0); return self
         async def __aexit__(self, *args): await asyncio.sleep(0)


### PR DESCRIPTION
## Summary
- Replace lambda placeholder for `is_reachable_async_func` with named async function `placeholder_is_reachable_async`
- Ensure async URL worker still awaits the reusable function

## Testing
- ⚠️ `python -m py_compile src/UFGS_CheckAllURLs_v4.py` (fails: SyntaxError: 'await' outside function)


------
https://chatgpt.com/codex/tasks/task_e_68a8e2e5c6b8832da9c96a4a11db095a