### PR TITLE
Remove leftover module-level PDFProcessor document property

### DIFF
--- a/pyqt-pdf-analyzer/core/pdf_processor.py
+++ b/pyqt-pdf-analyzer/core/pdf_processor.py
@@ -76,8 +76,3 @@ class PDFProcessor(QObject):
                 self.pipeline.document.close()
                 self.pipeline.document = None
                 self.pipeline.page_metadata.clear()
-
-@property
-def document(self):
-    """Provide backward compatibility for code expecting document attribute."""
-    return self.pipeline.document


### PR DESCRIPTION
## Summary
- clean up `pdf_processor.py` by deleting obsolete module-level `document` property
- rely on class `PDFProcessor.document` property for access to current PDF document

## Testing
- `pytest pyqt-pdf-analyzer/tests -q` *(fails: ModuleNotFoundError: No module named 'PyQt6')*

------
https://chatgpt.com/codex/tasks/task_e_68a8e2bc4f38832d92476133dd0b5476